### PR TITLE
chore!: update node support to require node 10 or later

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "presets": [
         ["@babel/preset-env", {
           "targets": {
-            "node": "8.11",
+            "node": "10",
             "browsers": [
               "last 2 versions",
               "not ie 1-11",
@@ -19,7 +19,7 @@
       "presets": [
         ["@babel/preset-env", {
           "targets": {
-            "node": "8.11",
+            "node": "10",
             "browsers": [
               "last 2 versions",
               "not ie 1-11",
@@ -35,7 +35,7 @@
       "presets": [
         ["@babel/preset-env", {
           "targets": {
-            "node": "8.11"
+            "node": "10"
           }
         }]
       ]

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Wowser Math should work with any browser that has native support for:
 Currently, the browser support targets are the latest 2 major versions of Chrome, Firefox, Safari,
 and Edge.
 
-Additionally, Node 8.7+ is supported.
+Additionally, Node 10+ is supported.


### PR DESCRIPTION
BREAKING CHANGE: We no longer support Node 8 or earlier. Node 10 is the oldest version actively maintained.