### PR TITLE
chore: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 [![Join Community](https://badgen.net/badge/discord/join%20community/blue)](https://discord.gg/DeVVKVg)
 [![Version](https://badgen.net/npm/v/@wowserhq/math)](https://www.npmjs.org/package/@wowserhq/math)
+[![MIT License](https://badgen.net/github/license/wowserhq/math)](LICENSE.md)
 [![CI](https://github.com/wowserhq/math/workflows/CI/badge.svg)](https://github.com/wowserhq/math/actions?query=workflow%3ACI)
 [![Test Coverage](https://codecov.io/gh/wowserhq/math/branch/master/graph/badge.svg)](https://codecov.io/gh/wowserhq/math)
 
 A 3D math library for Wowser.
-
-Licensed under the **MIT** license, see LICENSE for more information.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wowser Math
 
-[![Join Community](https://img.shields.io/badge/discord-join_community-blue.svg?style=flat)](https://discord.gg/DeVVKVg)
-[![Version](https://img.shields.io/npm/v/@wowserhq/math.svg?style=flat)](https://www.npmjs.org/package/@wowserhq/math)
+[![Join Community](https://badgen.net/badge/discord/join%20community/blue)](https://discord.gg/DeVVKVg)
+[![Version](https://badgen.net/npm/v/@wowserhq/math)](https://www.npmjs.org/package/@wowserhq/math)
 [![CI](https://github.com/wowserhq/math/workflows/CI/badge.svg)](https://github.com/wowserhq/math/actions?query=workflow%3ACI)
 [![Test Coverage](https://codecov.io/gh/wowserhq/math/branch/master/graph/badge.svg)](https://codecov.io/gh/wowserhq/math)
 


### PR DESCRIPTION
Couple of README badge changes:

- Are we okay with swapping to [badgen.net](https://github.com/badgen/)? Shields.io often ends up with broken badges.
- Adds a new LICENSE badge removing the text.