### PR TITLE
fix: use .mjs extensions for esm imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,21 @@ module.exports = {
           },
         ],
       ],
+      plugins: [
+        [
+          'module-resolver',
+          {
+            resolvePath: (sourcePath) => {
+              // Drop .mjs extensions in commonjs output
+              if (sourcePath.endsWith('.mjs')) {
+                return sourcePath.replace(/\.mjs$/, '');
+              }
+
+              return sourcePath;
+            },
+          },
+        ],
+      ],
     },
 
     esm: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5247,6 +5247,96 @@
         }
       }
     },
+    "babel-plugin-module-resolver": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.0.0.tgz",
+      "integrity": "sha512-3pdEq3PXALilSJ6dnC4wMWr0AZixHRM4utpdpBR9g5QG7B7JwWyukQv7a9hVxkbGFl+nQbrHDqqQOIBtTXTP/Q==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pkg-up": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+          "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -7982,6 +8072,24 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        }
+      }
+    },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
         }
       }
     },
@@ -13739,6 +13847,12 @@
           "dev": true
         }
       }
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "dev": true
     },
     "resolve": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@wowserhq/eslint-config": "0.3.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "26.0.1",
+    "babel-plugin-module-resolver": "4.0.0",
     "eslint": "4.19.1",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "21.22.0",

--- a/src/lib/Matrix3.mjs
+++ b/src/lib/Matrix3.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
 
-import { EPSILON } from './common';
+import { EPSILON } from './common.mjs';
 
 /**
  * Default values (identity)

--- a/src/lib/Matrix4.mjs
+++ b/src/lib/Matrix4.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
 
-import { EPSILON } from './common';
+import { EPSILON } from './common.mjs';
 
 /**
  * Default values (identity)

--- a/src/lib/Plane.mjs
+++ b/src/lib/Plane.mjs
@@ -1,4 +1,4 @@
-import { EPSILON } from './common';
+import { EPSILON } from './common.mjs';
 
 /**
  * Default values

--- a/src/lib/Quaternion.mjs
+++ b/src/lib/Quaternion.mjs
@@ -1,4 +1,4 @@
-import { EPSILON } from './common';
+import { EPSILON } from './common.mjs';
 
 /**
  * Default values

--- a/src/lib/Vector3.mjs
+++ b/src/lib/Vector3.mjs
@@ -1,4 +1,4 @@
-import { EPSILON } from './common';
+import { EPSILON } from './common.mjs';
 
 /**
  * Axis constants

--- a/src/lib/index.mjs
+++ b/src/lib/index.mjs
@@ -1,9 +1,9 @@
-import { DEG2RAD, EPSILON } from './common';
-import Matrix3 from './Matrix3';
-import Matrix4 from './Matrix4';
-import Plane from './Plane';
-import Quaternion from './Quaternion';
-import Vector3 from './Vector3';
+import { DEG2RAD, EPSILON } from './common.mjs';
+import Matrix3 from './Matrix3.mjs';
+import Matrix4 from './Matrix4.mjs';
+import Plane from './Plane.mjs';
+import Quaternion from './Quaternion.mjs';
+import Vector3 from './Vector3.mjs';
 
 export {
   DEG2RAD,


### PR DESCRIPTION
This should be the last fix necessary to properly support direct ESM-style imports from this package in recent versions of Node.js.