### PR TITLE
fix: use module field as esm hint for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "github:wowserhq/math",
   "license": "MIT",
   "main": "dist/index",
+  "module": "dist/index.mjs",
   "exports": {
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"


### PR DESCRIPTION
This should ensure webpack and other bundlers prefer the esm version of the code.

Entrypoints by environment:
- Node.js in cjs mode: ambiguous `main` `dist/index` resolves to `dist/index.js`
- Node.js in legacy esm mode: ambiguous `main` `dist/index` resolves to `dist/index.mjs`
- Node.js in modern esm mode: `exports.import` resolves to `dist/index.mjs`
- webpack: `module` resolves to `dist/index.mjs`